### PR TITLE
[OT129-80] Extender el servicio HTTP base para las peticiones de contactos

### DIFF
--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -28,7 +28,7 @@ const validationSchema = Yup.object({
 const ContactForm = () => {
   const onSubmit = (values, { resetForm }) => {
     resetForm();
-    createContact();
+    createContact(values);
   };
 
   return (

--- a/src/Components/Contact/ContactForm.js
+++ b/src/Components/Contact/ContactForm.js
@@ -4,6 +4,8 @@ import "../FormStyles.css";
 import * as Yup from "yup";
 import PropTypes from "prop-types";
 
+import { createContact } from "../../Services/ContactService";
+
 const ErrorComponent = (props) => <p>{props.children}</p>;
 
 const initialValues = {
@@ -26,6 +28,7 @@ const validationSchema = Yup.object({
 const ContactForm = () => {
   const onSubmit = (values, { resetForm }) => {
     resetForm();
+    createContact();
   };
 
   return (

--- a/src/Services/ContactService.js
+++ b/src/Services/ContactService.js
@@ -1,0 +1,15 @@
+import { get, post, put } from "./publicApiService";
+
+const ENDPOINT = "contacts";
+
+export const getContact = () => {
+  return get(ENDPOINT);
+};
+
+export const createContact = () => {
+  return post(ENDPOINT);
+};
+
+export const editContact = () => {
+  return put(ENDPOINT);
+};

--- a/src/Services/ContactService.js
+++ b/src/Services/ContactService.js
@@ -6,10 +6,10 @@ export const getContact = () => {
   return get(ENDPOINT);
 };
 
-export const createContact = () => {
-  return post(ENDPOINT);
+export const createContact = (data) => {
+  return post(ENDPOINT, data);
 };
 
-export const editContact = () => {
-  return put(ENDPOINT);
+export const editContact = (data, id) => {
+  return put(ENDPOINT, id, data);
 };


### PR DESCRIPTION
Was created a contact service file for specific requests related with contact components.

The only contact component that exist now is the contact form for users to send messages in the website. And the HTTP request that use is a POST request to send the messege. 

Evidence of the contact form sending the message correctly:

![contact save](https://user-images.githubusercontent.com/97997049/152193949-8a156978-336a-49bb-a1a0-b6b575002353.JPG)
